### PR TITLE
Added a comment to the zip file

### DIFF
--- a/commons_download_tool.py
+++ b/commons_download_tool.py
@@ -139,10 +139,12 @@ def get_all_files() -> None:
 	"""
 	global zip_file, nb_total_files
 
+	nb_total_files = len(filenames)
+
 	if not no_zip:
 		zip_file = zipfile.ZipFile(output, "w")
-
-	nb_total_files = len(filenames)
+		zip_file.comment = bytes(f"Archive containing {nb_total_files} recordings from Lingua Libre (lingualibre.org)",
+								 encoding="utf-8")
 
 	threads = []
 	for i in range(0, nb_threads):


### PR DESCRIPTION
# Description

This comment describes how many recordings are in the archive, and where they come from (lingualibre.org). 

The current comment is:

> Archive containing {nb_total_files} recordings from Lingua Libre (lingualibre.org)

Any thoughts about it? We can maybe improve it (up to a limit of 65535 bytes, [per the Python docs](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.comment)).

On Linux, the comment can be "seen" using the following command:

```bash
poslovitch@pop-os:~/Documents/Git/CommonsDownloadTool$ zipinfo -z test.zip
Archive:  test.zip
Archive containing 18245 recordings from Lingua Libre (lingualibre.org).
Zip file size: 93 bytes, number of entries: 0
Empty zipfile.
```

Aside from this, most languages (Java, Python, ...) provide an easy way to get an archive's comment. This begs the question: **should it be human-readable or machine-readable?**

# After the merge

We need to document properly this new behavior. Definitely on the README, but should it also be on Lingua Libre's [Help:Download datasets](https://lingualibre.org/wiki/Help:Download_datasets) ?